### PR TITLE
Fix empty table handle

### DIFF
--- a/src/unreconciled_lambda/unreconciled.py
+++ b/src/unreconciled_lambda/unreconciled.py
@@ -83,6 +83,7 @@ def unreconciled_after_max_age_query(args):
 
     return query
 
+
 def query_reconciled_and_unreconciled_counts(connection, args):
     query = reconciled_and_unreconciled_counts_query(args)
     logger.info(
@@ -90,7 +91,9 @@ def query_reconciled_and_unreconciled_counts(connection, args):
     )
     result = database.execute_query_to_dict(query, connection, "reconciled_result")
 
-    logger.info(f'Result for reconciled and unreconciled record counts", "result": "{result}')
+    logger.info(
+        f'Result for reconciled and unreconciled record counts", "result": "{result}'
+    )
 
     if result is not None and len(result) > 0:
         logger.info(f'Got result", "result": "{len(result) == 0}')
@@ -133,12 +136,16 @@ def reconciled_and_unreconciled_counts_query(args):
 
     return query
 
+
 def get_total_for_index(result, index):
     try:
         return result.get(index).get("total")
     except:
-        logger.info(f'Result has an empty row, returning zero", "result": "{result}", "index": "{index}')
+        logger.info(
+            f'Result has an empty row, returning zero", "result": "{result}", "index": "{index}'
+        )
         return 0
+
 
 if __name__ == "__main__":
     script_dir = os.path.dirname(__file__)

--- a/src/unreconciled_lambda/unreconciled.py
+++ b/src/unreconciled_lambda/unreconciled.py
@@ -83,7 +83,6 @@ def unreconciled_after_max_age_query(args):
 
     return query
 
-
 def query_reconciled_and_unreconciled_counts(connection, args):
     query = reconciled_and_unreconciled_counts_query(args)
     logger.info(
@@ -91,10 +90,12 @@ def query_reconciled_and_unreconciled_counts(connection, args):
     )
     result = database.execute_query_to_dict(query, connection, "reconciled_result")
 
+    logger.info(f'Result for reconciled and unreconciled record counts", "result": "{result}')
+
     if result is not None and len(result) > 0:
         logger.info(f'Got result", "result": "{len(result) == 0}')
-        unreconciled_count = result.get(0).get("total")
-        reconciled_count = result.get(1).get("total")
+        unreconciled_count = get_total_for_index(result, 0)
+        reconciled_count = get_total_for_index(result, 1)
         logger.info(
             f'Got result for reconciled and unreconciled records", "unreconciled_count": "{unreconciled_count}", '
             f'"reconciled_count": "{reconciled_count}'
@@ -132,6 +133,12 @@ def reconciled_and_unreconciled_counts_query(args):
 
     return query
 
+def get_total_for_index(result, index):
+    try:
+        return result.get(index).get("total")
+    except:
+        logger.info(f'Result has an empty row, returning zero", "result": "{result}", "index": "{index}')
+        return 0
 
 if __name__ == "__main__":
     script_dir = os.path.dirname(__file__)

--- a/src/unreconciled_lambda/unreconciled.py
+++ b/src/unreconciled_lambda/unreconciled.py
@@ -96,7 +96,7 @@ def query_reconciled_and_unreconciled_counts(connection, args):
         unreconciled_count = result.get(0).get("total")
         reconciled_count = result.get(1).get("total")
         logger.info(
-            f'Got result for reconciled and unreconciled records", "unreconciled_count": "{unreconciled_count}, '
+            f'Got result for reconciled and unreconciled records", "unreconciled_count": "{unreconciled_count}", '
             f'"reconciled_count": "{reconciled_count}'
         )
     else:


### PR DESCRIPTION
When unreconciled or reconciled is an empty row it is erroring when fetching for the index.

Fix this by having it in a try catch and if either error in this case, we can return a zero value and log that this was raised.